### PR TITLE
[VER-5805]bootstrap-play upgrade: Iv-orchestration

### DIFF
--- a/app/uk/gov/hmrc/ivorchestration/controllers/documentation/IvOrchestrationDocumentationController.scala
+++ b/app/uk/gov/hmrc/ivorchestration/controllers/documentation/IvOrchestrationDocumentationController.scala
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package uk.gov.hmrc.ivorchestration.controllers
+package uk.gov.hmrc.ivorchestration.controllers.documentation
 
 import controllers.Assets
 import play.api.http.HttpErrorHandler

--- a/build.sbt
+++ b/build.sbt
@@ -36,6 +36,7 @@ lazy val microservice = Project(appName, file("."))
       "-Wconf:src=routes/.*:s"
     )
   )
+  .settings(Compile / unmanagedResourceDirectories += baseDirectory.value / "resources")
 
 lazy val scoverageSettings =
   Seq(

--- a/build.sbt
+++ b/build.sbt
@@ -1,7 +1,6 @@
 import sbt.Keys.*
 import sbt.*
 import scoverage.ScoverageKeys
-import uk.gov.hmrc.DefaultBuildSettings.scalaSettings
 
 val appName = "iv-orchestration"
 
@@ -29,19 +28,19 @@ lazy val microservice = Project(appName, file("."))
   .settings(
     PlayKeys.playDefaultPort := 9276,
     scoverageSettings,
-    scalaSettings,
     libraryDependencies ++= AppDependencies.compile ++ AppDependencies.test,
     scalacOptions ++= Seq(
-      "-Wconf:cat=unused-imports&src=routes/.*:s",
-    "-Wunused",
-    "-Wdead-code"
+      "-Wconf:cat=unused-imports&src=views/.*:s",
+      "-Wunused",
+      "-Wdead-code",
+      "-Wconf:src=routes/.*:s"
     )
   )
 
 lazy val scoverageSettings =
   Seq(
-    ScoverageKeys.coverageExcludedPackages := "<empty>;Reverse.*;models/.data/..*;view.*;.*(AuthService|BuildInfo|Routes).*",
-    ScoverageKeys.coverageMinimumStmtTotal := 85,
+    ScoverageKeys.coverageExcludedPackages := excludedPackages.mkString(";"),
+    ScoverageKeys.coverageMinimumStmtTotal := 94,
     ScoverageKeys.coverageFailOnMinimum := true,
     ScoverageKeys.coverageHighlighting := true
   )

--- a/build.sbt
+++ b/build.sbt
@@ -1,8 +1,12 @@
-import play.sbt.PlayImport.PlayKeys.playDefaultPort
-import sbt.Keys._
-import sbt._
+import sbt.Keys.*
+import sbt.*
+import scoverage.ScoverageKeys
+import uk.gov.hmrc.DefaultBuildSettings.scalaSettings
 
 val appName = "iv-orchestration"
+
+ThisBuild / majorVersion := 2
+ThisBuild / scalaVersion := "2.13.16"
 
 val excludedPackages = Seq(
   "<empty>",
@@ -20,15 +24,28 @@ lazy val microservice = Project(appName, file("."))
   .enablePlugins(play.sbt.PlayScala, SbtDistributablesPlugin)
   .disablePlugins(JUnitXmlReportPlugin)
   .settings(
-    majorVersion                     := 2,
-    libraryDependencies              ++= AppDependencies.compile ++ AppDependencies.test,
-      evictionWarningOptions           := EvictionWarningOptions.default.withWarnEvictionSummary(false)
+      evictionWarningOptions  := EvictionWarningOptions.default.withWarnEvictionSummary(false)
   )
-  .settings(scalaVersion := "2.13.16")
-  .settings(scalacOptions += "-Wconf:cat=unused-imports&src=routes/.*:s")
-  .settings(resolvers += Resolver.jcenterRepo)
-  .settings(playDefaultPort := 9276)
-  .settings(coverageMinimumStmtTotal := 85)
-  .settings(coverageFailOnMinimum := true)
-  .settings(coverageExcludedPackages := excludedPackages.mkString(";"))
-  .settings(Compile / unmanagedResourceDirectories += baseDirectory.value / "resources")
+  .settings(
+    PlayKeys.playDefaultPort := 9276,
+    scoverageSettings,
+    scalaSettings,
+    libraryDependencies ++= AppDependencies.compile ++ AppDependencies.test,
+    scalacOptions ++= Seq(
+      "-Wconf:cat=unused-imports&src=routes/.*:s",
+    "-Wunused",
+    "-Wdead-code"
+    )
+  )
+
+lazy val scoverageSettings =
+  Seq(
+    ScoverageKeys.coverageExcludedPackages := "<empty>;Reverse.*;models/.data/..*;view.*;.*(AuthService|BuildInfo|Routes).*",
+    ScoverageKeys.coverageMinimumStmtTotal := 85,
+    ScoverageKeys.coverageFailOnMinimum := true,
+    ScoverageKeys.coverageHighlighting := true
+  )
+
+Test / parallelExecution := true
+Test / Keys.fork := true
+Test / scalacOptions --= Seq("-Wdead-code", "-Wvalue-discard")

--- a/conf/app.routes
+++ b/conf/app.routes
@@ -1,4 +1,3 @@
-# microservice specific routes
 
 POST   /iv-sessiondata           uk.gov.hmrc.ivorchestration.controllers.IvSessionDataController.ivSessionData()
 POST   /iv-sessiondata/search    uk.gov.hmrc.ivorchestration.controllers.IvSessionDataController.searchIvSessionData()

--- a/conf/app.routes
+++ b/conf/app.routes
@@ -1,3 +1,4 @@
+# app.routes
 
 POST   /iv-sessiondata           uk.gov.hmrc.ivorchestration.controllers.IvSessionDataController.ivSessionData()
 POST   /iv-sessiondata/search    uk.gov.hmrc.ivorchestration.controllers.IvSessionDataController.searchIvSessionData()

--- a/conf/definition.routes
+++ b/conf/definition.routes
@@ -1,3 +1,4 @@
+# definition.routes
 
-GET        /api/definition             uk.gov.hmrc.ivorchestration.controllers.IvOrchestrationDocumentationController.definition()
-GET        /api/conf/:version/*file    uk.gov.hmrc.ivorchestration.controllers.IvOrchestrationDocumentationController.conf(version, file)
+GET        /api/definition             uk.gov.hmrc.ivorchestration.controllers.documentation.IvOrchestrationDocumentationController.definition()
+GET        /api/conf/:version/*file    uk.gov.hmrc.ivorchestration.controllers.documentation.IvOrchestrationDocumentationController.conf(version, file)

--- a/conf/definition.routes
+++ b/conf/definition.routes
@@ -1,4 +1,3 @@
 
-
 GET        /api/definition             uk.gov.hmrc.ivorchestration.controllers.IvOrchestrationDocumentationController.definition()
 GET        /api/conf/:version/*file    uk.gov.hmrc.ivorchestration.controllers.IvOrchestrationDocumentationController.conf(version, file)

--- a/conf/prod.routes
+++ b/conf/prod.routes
@@ -2,4 +2,3 @@
 ->         /                          app.Routes
 ->         /                          definition.Routes
 ->         /                          health.Routes
-

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -1,10 +1,10 @@
 import play.core.PlayVersion.current
-import sbt._
+import sbt.*
 
 object AppDependencies {
 
-  val bootStrapVersion: String = "9.11.0"
-  val mongoVersion: String = "2.6.0"
+  val bootStrapVersion: String = "9.14.0"
+  val mongoVersion: String = "2.7.0"
 
   val compile: Seq[ModuleID] = Seq(
     "uk.gov.hmrc.mongo"          %% "hmrc-mongo-play-30"         % mongoVersion,
@@ -13,11 +13,10 @@ object AppDependencies {
   )
 
   val test: Seq[ModuleID] = Seq(
-    "uk.gov.hmrc"             %% "bootstrap-test-play-30"   % bootStrapVersion        % Test,
-    "org.scalamock"           %% "scalamock"                % "7.3.2"                 % Test,
-    "org.playframework"       %% "play-test"                % current                 % Test,
-    "org.pegdown"             %  "pegdown"                  % "1.6.0"                 % Test,
-    "org.scalatestplus.play"  %% "scalatestplus-play"       % "7.0.1"                 % Test,
-    "com.vladsch.flexmark"    %  "flexmark-all"             % "0.64.8"                % Test
-  )
+    "uk.gov.hmrc"             %% "bootstrap-test-play-30"   % bootStrapVersion,
+    "org.scalamock"           %% "scalamock"                % "7.4.1",
+    "org.playframework"       %% "play-test"                % current,
+    "org.scalatestplus.play"  %% "scalatestplus-play"       % "7.0.2",
+    "com.vladsch.flexmark"    %  "flexmark-all"             % "0.64.8"
+  ).map(_ % "test")
 }

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -3,11 +3,8 @@ resolvers += Resolver.url("HMRC-open-artefacts-ivy", url("https://open.artefacts
 resolvers += MavenRepository("HMRC-open-artefacts-maven2", "https://open.artefacts.tax.service.gov.uk/maven2")
 
 
-addSbtPlugin("uk.gov.hmrc" % "sbt-auto-build" % "3.24.0")
-
-addSbtPlugin("uk.gov.hmrc" % "sbt-distributables" % "2.6.0")
-
-addSbtPlugin("org.playframework" % "sbt-plugin" % "3.0.6")
-
-addSbtPlugin("org.scoverage" % "sbt-scoverage" % "2.3.1")
+addSbtPlugin("uk.gov.hmrc"       % "sbt-auto-build"     % "3.24.0")
+addSbtPlugin("uk.gov.hmrc"       % "sbt-distributables" % "2.6.0")
+addSbtPlugin("org.playframework" % "sbt-plugin"         % "3.0.8")
+addSbtPlugin("org.scoverage"     % "sbt-scoverage"      % "2.3.1")
 

--- a/test/uk/gov/hmrc/ivorchestration/controllers/DocumentationControllerSpec.scala
+++ b/test/uk/gov/hmrc/ivorchestration/controllers/DocumentationControllerSpec.scala
@@ -22,6 +22,7 @@ import play.api.test.FakeRequest
 import uk.gov.hmrc.http.HeaderCarrier
 import uk.gov.hmrc.ivorchestration.testsuite.BaseSpec
 import play.api.test.Helpers._
+import uk.gov.hmrc.ivorchestration.controllers.documentation.IvOrchestrationDocumentationController
 
 
 class DocumentationControllerSpec extends BaseSpec with GuiceOneAppPerSuite with MockFactory {


### PR DESCRIPTION
play-hmrc-api cannot be upgraded any further because this Library now uses scala 3 and requires play 3.0

<img width="707" height="275" alt="Screenshot 2025-08-29 at 09 41 26" src="https://github.com/user-attachments/assets/cd4e3a72-5b2b-4b06-bfaf-b0cd9e36df93" />
<img width="880" height="319" alt="Screenshot 2025-08-29 at 09 39 01" src="https://github.com/user-attachments/assets/79728f67-0c19-49d2-87d6-e4380ea4de26" />

