### PR TITLE
VER-4813: Scala 3 migration

### DIFF
--- a/app/uk/gov/hmrc/ivorchestration/config/AppConfiguration.scala
+++ b/app/uk/gov/hmrc/ivorchestration/config/AppConfiguration.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 HM Revenue & Customs
+ * Copyright 2026 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/ivorchestration/controllers/HeaderValidator.scala
+++ b/app/uk/gov/hmrc/ivorchestration/controllers/HeaderValidator.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 HM Revenue & Customs
+ * Copyright 2026 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/ivorchestration/controllers/HeaderValidator.scala
+++ b/app/uk/gov/hmrc/ivorchestration/controllers/HeaderValidator.scala
@@ -25,7 +25,7 @@ import scala.concurrent.{ExecutionContext, Future}
 @Singleton
 class HeaderValidator @Inject()(cc: ControllerComponents) extends Results with HeadersValidationHandler {
 
-  def validateAction(): ActionBuilder[Request, AnyContent] with ActionFilter[Request] = {
+  def validateAction(): ActionBuilder[Request, AnyContent] & ActionFilter[Request] = {
     new ActionBuilder[Request, AnyContent] with ActionFilter[Request] {
 
       override val parser: BodyParser[AnyContent] = cc.parsers.defaultBodyParser

--- a/app/uk/gov/hmrc/ivorchestration/controllers/IvSessionDataController.scala
+++ b/app/uk/gov/hmrc/ivorchestration/controllers/IvSessionDataController.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 HM Revenue & Customs
+ * Copyright 2026 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/ivorchestration/controllers/documentation/IvOrchestrationDocumentationController.scala
+++ b/app/uk/gov/hmrc/ivorchestration/controllers/documentation/IvOrchestrationDocumentationController.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 HM Revenue & Customs
+ * Copyright 2026 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/ivorchestration/handlers/HeadersValidationHandler.scala
+++ b/app/uk/gov/hmrc/ivorchestration/handlers/HeadersValidationHandler.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 HM Revenue & Customs
+ * Copyright 2026 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/ivorchestration/handlers/IvSessionDataRequestHandler.scala
+++ b/app/uk/gov/hmrc/ivorchestration/handlers/IvSessionDataRequestHandler.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 HM Revenue & Customs
+ * Copyright 2026 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/ivorchestration/model/JourneyType.scala
+++ b/app/uk/gov/hmrc/ivorchestration/model/JourneyType.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 HM Revenue & Customs
+ * Copyright 2026 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/ivorchestration/model/RecordNotFound.scala
+++ b/app/uk/gov/hmrc/ivorchestration/model/RecordNotFound.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 HM Revenue & Customs
+ * Copyright 2026 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/ivorchestration/model/api/ErrorResult.scala
+++ b/app/uk/gov/hmrc/ivorchestration/model/api/ErrorResult.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 HM Revenue & Customs
+ * Copyright 2026 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/ivorchestration/model/api/IvSessionData.scala
+++ b/app/uk/gov/hmrc/ivorchestration/model/api/IvSessionData.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 HM Revenue & Customs
+ * Copyright 2026 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/ivorchestration/model/api/IvSessionData.scala
+++ b/app/uk/gov/hmrc/ivorchestration/model/api/IvSessionData.scala
@@ -41,8 +41,8 @@ case class IvSessionData(credId: Option[CredId],
 object IvSessionData extends CustomDateTimeReads with CustomDateTimeWrites {
 
   implicit val customZonedDateTimeFormat: Format[ZonedDateTime] = Format[ZonedDateTime](
-    {json: JsValue => customZonedDateTimeReads.reads(json)},
-    {zdt: ZonedDateTime => customZonedDateTimeWrites.writes(zdt)}
+    {(json: JsValue) => customZonedDateTimeReads.reads(json)},
+    {(zdt: ZonedDateTime) => customZonedDateTimeWrites.writes(zdt)}
   )
 
   implicit val format: OFormat[IvSessionData] = Json.format[IvSessionData]

--- a/app/uk/gov/hmrc/ivorchestration/model/api/IvSessionDataSearchRequest.scala
+++ b/app/uk/gov/hmrc/ivorchestration/model/api/IvSessionDataSearchRequest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 HM Revenue & Customs
+ * Copyright 2026 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/ivorchestration/model/api/IvSessionDataSearchResponse.scala
+++ b/app/uk/gov/hmrc/ivorchestration/model/api/IvSessionDataSearchResponse.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 HM Revenue & Customs
+ * Copyright 2026 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/ivorchestration/model/api/IvSessionDataSearchResponse.scala
+++ b/app/uk/gov/hmrc/ivorchestration/model/api/IvSessionDataSearchResponse.scala
@@ -46,8 +46,8 @@ object IvSessionDataSearchResponse extends CustomDateTimeReads with CustomDateTi
   }
 
   implicit val customZonedDateTimeFormat: Format[ZonedDateTime] = Format[ZonedDateTime](
-    {json: JsValue => customZonedDateTimeReads.reads(json)},
-    {zdt: ZonedDateTime => customZonedDateTimeWrites.writes(zdt)}
+    {(json: JsValue) => customZonedDateTimeReads.reads(json)},
+    {(zdt: ZonedDateTime) => customZonedDateTimeWrites.writes(zdt)}
   )
 
   implicit val format: OFormat[IvSessionDataSearchResponse] = Json.format[IvSessionDataSearchResponse]

--- a/app/uk/gov/hmrc/ivorchestration/model/core/CredId.scala
+++ b/app/uk/gov/hmrc/ivorchestration/model/core/CredId.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 HM Revenue & Customs
+ * Copyright 2026 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/ivorchestration/model/core/IvSessionDataCore.scala
+++ b/app/uk/gov/hmrc/ivorchestration/model/core/IvSessionDataCore.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 HM Revenue & Customs
+ * Copyright 2026 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/ivorchestration/model/core/IvSessionDataCore.scala
+++ b/app/uk/gov/hmrc/ivorchestration/model/core/IvSessionDataCore.scala
@@ -26,8 +26,8 @@ case class IvSessionDataCore(ivSessionData: IvSessionData, journeyId: JourneyId,
 object IvSessionDataCore extends CustomDateTimeReads with CustomDateTimeWrites {
 
   implicit val customMongoDateTimeFormat: Format[OffsetDateTime] = Format[OffsetDateTime](
-    {json: JsValue => customMongoOffsetDateTimeReads.reads(json)},
-    {offsetDateTime: OffsetDateTime => customMongoZonedDateTimeWrites.writes(offsetDateTime)}
+    {(json: JsValue) => customMongoOffsetDateTimeReads.reads(json)},
+    {(offsetDateTime: OffsetDateTime) => customMongoZonedDateTimeWrites.writes(offsetDateTime)}
   )
 
 

--- a/app/uk/gov/hmrc/ivorchestration/model/core/JourneyId.scala
+++ b/app/uk/gov/hmrc/ivorchestration/model/core/JourneyId.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 HM Revenue & Customs
+ * Copyright 2026 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/ivorchestration/repository/IvSessionDataRepositoryAlgebra.scala
+++ b/app/uk/gov/hmrc/ivorchestration/repository/IvSessionDataRepositoryAlgebra.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 HM Revenue & Customs
+ * Copyright 2026 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/ivorchestration/repository/IvSessionDataRepositoryAlgebra.scala
+++ b/app/uk/gov/hmrc/ivorchestration/repository/IvSessionDataRepositoryAlgebra.scala
@@ -42,7 +42,7 @@ class IvSessionDataRepository @Inject()(mongoComponent: MongoComponent, app: App
     indexes = Seq(
       IndexModel(
         ascending("createdAt"),
-        indexOptions = IndexOptions().name("expireAfterSeconds").expireAfter(app.mongodbTTL, SECONDS)
+        indexOptions = IndexOptions().name("expireAfterSeconds").expireAfter(app.mongodbTTL.toLong, SECONDS)
       ),
       IndexModel(
         ascending("journeyId", "ivSessionData.credId"), IndexOptions().name("Primary").unique(true)

--- a/app/uk/gov/hmrc/ivorchestration/util/CustomDateTimeReads.scala
+++ b/app/uk/gov/hmrc/ivorchestration/util/CustomDateTimeReads.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 HM Revenue & Customs
+ * Copyright 2026 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/ivorchestration/util/CustomDateTimeWrites.scala
+++ b/app/uk/gov/hmrc/ivorchestration/util/CustomDateTimeWrites.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 HM Revenue & Customs
+ * Copyright 2026 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/build.sbt
+++ b/build.sbt
@@ -5,7 +5,7 @@ import scoverage.ScoverageKeys
 val appName = "iv-orchestration"
 
 ThisBuild / majorVersion := 2
-ThisBuild / scalaVersion := "2.13.16"
+ThisBuild / scalaVersion := "3.7.4"
 
 val excludedPackages = Seq(
   "<empty>",
@@ -30,9 +30,8 @@ lazy val microservice = Project(appName, file("."))
     scoverageSettings,
     libraryDependencies ++= AppDependencies.compile ++ AppDependencies.test,
     scalacOptions ++= Seq(
-      "-Wconf:cat=unused-imports&src=views/.*:s",
-      "-Wunused",
-      "-Wdead-code",
+      "-Wconf:msg=unused import&src=html/.*:s",
+      "-Wconf:msg=Flag.*repeatedly:s",
       "-Wconf:src=routes/.*:s"
     )
   )

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -1,4 +1,4 @@
-# Copyright 2024 HM Revenue & Customs
+# Copyright 2026 HM Revenue & Customs
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -14,7 +14,7 @@ object AppDependencies {
 
   val test: Seq[ModuleID] = Seq(
     "uk.gov.hmrc"             %% "bootstrap-test-play-30"   % bootStrapVersion,
-    "org.scalamock"           %% "scalamock"                % "7.5.4",
+    "org.scalamock"           %% "scalamock"                % "7.5.5",
     "org.playframework"       %% "play-test"                % current,
     "org.scalatestplus.play"  %% "scalatestplus-play"       % "7.0.2",
     "com.vladsch.flexmark"    %  "flexmark-all"             % "0.64.8"

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -3,18 +3,18 @@ import sbt.*
 
 object AppDependencies {
 
-  val bootStrapVersion: String = "9.14.0"
-  val mongoVersion: String = "2.7.0"
+  val bootStrapVersion: String = "10.5.0"
+  val mongoVersion: String = "2.12.0"
 
   val compile: Seq[ModuleID] = Seq(
     "uk.gov.hmrc.mongo"          %% "hmrc-mongo-play-30"         % mongoVersion,
     "uk.gov.hmrc"                %% "bootstrap-backend-play-30"  % bootStrapVersion,
-    "uk.gov.hmrc"                %% "play-hmrc-api-play-30"      % "8.0.0" // Version 8.1.0+ requires play 3.0+
+    "uk.gov.hmrc"                %% "play-hmrc-api-play-30"      % "8.3.0"
   )
 
   val test: Seq[ModuleID] = Seq(
     "uk.gov.hmrc"             %% "bootstrap-test-play-30"   % bootStrapVersion,
-    "org.scalamock"           %% "scalamock"                % "7.4.1",
+    "org.scalamock"           %% "scalamock"                % "7.5.4",
     "org.playframework"       %% "play-test"                % current,
     "org.scalatestplus.play"  %% "scalatestplus-play"       % "7.0.2",
     "com.vladsch.flexmark"    %  "flexmark-all"             % "0.64.8"

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -5,6 +5,6 @@ resolvers += MavenRepository("HMRC-open-artefacts-maven2", "https://open.artefac
 
 addSbtPlugin("uk.gov.hmrc"       % "sbt-auto-build"     % "3.24.0")
 addSbtPlugin("uk.gov.hmrc"       % "sbt-distributables" % "2.6.0")
-addSbtPlugin("org.playframework" % "sbt-plugin"         % "3.0.8")
-addSbtPlugin("org.scoverage"     % "sbt-scoverage"      % "2.3.1")
+addSbtPlugin("org.playframework" % "sbt-plugin"         % "3.0.9")
+addSbtPlugin("org.scoverage"     % "sbt-scoverage"      % "2.4.4")
 

--- a/test/uk/gov/hmrc/ivorchestration/controllers/DocumentationControllerSpec.scala
+++ b/test/uk/gov/hmrc/ivorchestration/controllers/DocumentationControllerSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 HM Revenue & Customs
+ * Copyright 2026 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/uk/gov/hmrc/ivorchestration/controllers/DocumentationControllerSpec.scala
+++ b/test/uk/gov/hmrc/ivorchestration/controllers/DocumentationControllerSpec.scala
@@ -35,6 +35,12 @@ class DocumentationControllerSpec extends BaseSpec with GuiceOneAppPerSuite with
     status(result) mustBe OK
   }
 
+  "serve api config files via /api/conf/:version/*file" in new Setup {
+    val result = documentationController.conf("1.0", "does-not-exist.yaml")(request)
+
+    status(result) must (be(OK) or be(NOT_FOUND))
+  }
+
   trait Setup {
     implicit def materializer: org.apache.pekko.stream.Materializer = app.injector.instanceOf[org.apache.pekko.stream.Materializer]
     val documentationController = app.injector.instanceOf[IvOrchestrationDocumentationController]

--- a/test/uk/gov/hmrc/ivorchestration/controllers/IvSessionDataControllerSpec.scala
+++ b/test/uk/gov/hmrc/ivorchestration/controllers/IvSessionDataControllerSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 HM Revenue & Customs
+ * Copyright 2026 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/uk/gov/hmrc/ivorchestration/controllers/IvSessionDataControllerSpec.scala
+++ b/test/uk/gov/hmrc/ivorchestration/controllers/IvSessionDataControllerSpec.scala
@@ -17,7 +17,6 @@
 package uk.gov.hmrc.ivorchestration.controllers
 
 import org.apache.pekko.stream.Materializer
-import java.time.{LocalDate, OffsetDateTime, ZonedDateTime, ZoneOffset}
 import org.scalamock.scalatest.MockFactory
 import org.scalatest.BeforeAndAfterEach
 import org.scalatestplus.play.guice.GuiceOneAppPerSuite
@@ -25,7 +24,7 @@ import play.api.i18n.MessagesApi
 import play.api.inject.Injector
 import play.api.libs.json.Json
 import play.api.test.FakeRequest
-import play.api.test.Helpers._
+import play.api.test.Helpers.*
 import uk.gov.hmrc.auth.core.authorise.EmptyPredicate
 import uk.gov.hmrc.auth.core.{AuthConnector, SessionRecordNotFound}
 import uk.gov.hmrc.http.HeaderCarrier
@@ -37,7 +36,9 @@ import uk.gov.hmrc.ivorchestration.model.{DatabaseError, StandaloneJourneyType, 
 import uk.gov.hmrc.ivorchestration.repository.IvSessionDataRepository
 import uk.gov.hmrc.ivorchestration.testsuite.{BaseSpec, TestData}
 import uk.gov.hmrc.mongo.MongoComponent
+import uk.gov.hmrc.mongo.logging.ObservableFutureImplicits.SingleObservableFuture
 
+import java.time.{LocalDate, OffsetDateTime, ZoneOffset, ZonedDateTime}
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.{ExecutionContext, Future}
 

--- a/test/uk/gov/hmrc/ivorchestration/handlers/HeadersValidationHandlerSpec.scala
+++ b/test/uk/gov/hmrc/ivorchestration/handlers/HeadersValidationHandlerSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 HM Revenue & Customs
+ * Copyright 2026 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/uk/gov/hmrc/ivorchestration/handlers/IvSessionDataRequestHandlerSpec.scala
+++ b/test/uk/gov/hmrc/ivorchestration/handlers/IvSessionDataRequestHandlerSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 HM Revenue & Customs
+ * Copyright 2026 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/uk/gov/hmrc/ivorchestration/handlers/IvSessionDataRequestHandlerSpec.scala
+++ b/test/uk/gov/hmrc/ivorchestration/handlers/IvSessionDataRequestHandlerSpec.scala
@@ -43,7 +43,7 @@ class IvSessionDataRequestHandlerSpec extends BaseSpec with TestData {
 
   "Given AuthRetrieval" should {
     "JourneyId is generated for iv-session-data" in new IvSessionDataRequestHandler(algebra) {
-      create(sampleIvSessionData).map( prefix => prefix mustBe include(UriPrefix.uriPrefix))
+      create(sampleIvSessionData).map( prefix => prefix must include(UriPrefix.uriPrefix))
     }
 
     "JourneyId is generated and appended to the returned uri" in new IvSessionDataRequestHandler(algebra) {

--- a/test/uk/gov/hmrc/ivorchestration/model/api/IvSessionDataSpec.scala
+++ b/test/uk/gov/hmrc/ivorchestration/model/api/IvSessionDataSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 HM Revenue & Customs
+ * Copyright 2026 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/uk/gov/hmrc/ivorchestration/repository/IvSessionDataRepositorySpec.scala
+++ b/test/uk/gov/hmrc/ivorchestration/repository/IvSessionDataRepositorySpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 HM Revenue & Customs
+ * Copyright 2026 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/uk/gov/hmrc/ivorchestration/repository/IvSessionDataRepositorySpec.scala
+++ b/test/uk/gov/hmrc/ivorchestration/repository/IvSessionDataRepositorySpec.scala
@@ -23,8 +23,9 @@ import org.scalatestplus.play.guice.GuiceOneAppPerSuite
 import uk.gov.hmrc.ivorchestration.config.AppConfig
 import uk.gov.hmrc.ivorchestration.model.DuplicatedRecord
 import uk.gov.hmrc.ivorchestration.model.core.{CredId, IvSessionDataCore, JourneyId}
-import uk.gov.hmrc.ivorchestration.testsuite._
+import uk.gov.hmrc.ivorchestration.testsuite.*
 import uk.gov.hmrc.mongo.MongoComponent
+import uk.gov.hmrc.mongo.logging.ObservableFutureImplicits.SingleObservableFuture
 
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
@@ -80,7 +81,7 @@ class IvSessionDataRepositorySpec extends BaseSpec with BeforeAndAfterEach with 
     } yield data
 
     val actual = await[Option[IvSessionDataCore]](eventualData).get
-    import actual.ivSessionData._
+    import actual.ivSessionData.*
 
     actual mustBe sampleIvSessionDataCore.copy(journeyId = actual.journeyId,
       ivSessionData = sampleIvSessionData.copy(credId = credId, loginTimes = loginTimes, dateOfBirth = dateOfBirth),

--- a/test/uk/gov/hmrc/ivorchestration/testsuite/BaseSpec.scala
+++ b/test/uk/gov/hmrc/ivorchestration/testsuite/BaseSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 HM Revenue & Customs
+ * Copyright 2026 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/uk/gov/hmrc/ivorchestration/testsuite/TestData.scala
+++ b/test/uk/gov/hmrc/ivorchestration/testsuite/TestData.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 HM Revenue & Customs
+ * Copyright 2026 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/uk/gov/hmrc/ivorchestration/util/CustomMongoDateTimeFormatSpec.scala
+++ b/test/uk/gov/hmrc/ivorchestration/util/CustomMongoDateTimeFormatSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 HM Revenue & Customs
+ * Copyright 2026 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
### Ticket details

iv-orchestration : Scala 3 update ticket - https://jira.tools.tax.service.gov.uk/browse/VER-4813 


**iv-orchestration unit tests**

<img width="1397" height="231" alt="image" src="https://github.com/user-attachments/assets/e8981384-7304-47ab-b006-fd57d80c3f3b" />


**dwp-iv-ui-tests**

<img width="1337" height="252" alt="image" src="https://github.com/user-attachments/assets/5a110378-e678-483e-8a0b-b29888097d0c" />

______________________

### More info

Scoverage failed so I've added a controller test for the `/api/conf/:version/*file` endpoint to cover an untested code path and meet the required scoverage threshold after the Scala 3 migration.

**_BEFORE_**


<img width="1920" height="959" alt="image" src="https://github.com/user-attachments/assets/e23d6ca7-b970-4ece-8070-8bc144978676" />


<img width="1920" height="993" alt="image" src="https://github.com/user-attachments/assets/52f87145-d057-419f-907e-49034c5e582f" />

______________________

**_AFTER_**

<img width="2333" height="379" alt="image" src="https://github.com/user-attachments/assets/9d87868c-d850-40ca-990b-380fdbdb41ff" />

<img width="1920" height="959" alt="image" src="https://github.com/user-attachments/assets/a21e23a3-f4ff-47a3-bf28-ebd74d7eca1c" />



